### PR TITLE
Cargo.toml: replace coreos with flatcar-linux for repository for alpha 2345

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "update-ssh-keys"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]
 license = "Apache-2.0"
-repository = "https://github.com/coreos/update-ssh-keys"
+repository = "https://github.com/flatcar-linux/update-ssh-keys"
 documentation = "https://docs.rs/update-ssh-keys"
 description = "A tool for managing authorized SSH keys"
 version = "0.4.2-alpha.0"


### PR DESCRIPTION
In `Cargo.toml`, the `repository` entry should point to `github.com/flatcar-linux/update-ssh-keys`.

The change will be needed by upcoming changes in coreos-overlay, so Alpha and Edge branches could point to correct commit IDs for the flatcar-linux repo.