### PR TITLE
Cargo: set LTO option to false == thin-local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/lib.rs"
 doc = true
 
 [profile.release]
-lto = true
+lto = false
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Gentoo ebuild of Rust 1.70 started showing different behavior w.r.t. LTO. That makes builds fail like:

```
rustc: .../InstructionPrecedenceTracking.cpp:97:
void llvm::InstructionPrecedenceTracking::validate(const
llvm::BasicBlock*) const: Assertion `It->second == nullptr && "Block is
marked as having special instructions but in fact it  has " "none!"'
failed.
error: could not compile `update-ssh-keys` (bin "update-ssh-keys")
```

Changing `lto = true` to `lto = false` (a.k.a. "thin-local") in `Cargo.toml` makes the build failure disappear.
