### PR TITLE
Address cargo fmt and clippy issues

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,37 @@
-name: Rust
+name: Run Rust CI
 
 on:
   push:
-    branches: [ flatcar-master ]
+    branches:
+      - flatcar-master
   pull_request:
-    branches: [ flatcar-master ]
-
-env:
-  CARGO_TERM_COLOR: always
+    branches:
+      - flatcar-master
 
 jobs:
-  build:
-
+  build-test:
+    name: Build and test update-ssh-keys
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - name: Rustfmt Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
+      - name: Build update-ssh-keys
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+      - name: Run unit tests of update-ssh-keys
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ impl AuthorizedKeys {
 
         // destroy the old authorized keys file and move the staging one to that
         // location
-        fs::rename(&stage_filename, &self.authorized_keys_file()).chain_err(|| {
+        fs::rename(&stage_filename, self.authorized_keys_file()).chain_err(|| {
             format!(
                 "failed to move '{:?}' to '{:?}'",
                 stage_filename,
@@ -381,7 +381,7 @@ impl AuthorizedKeys {
     /// files
     fn read_all_keys(dir: &Path) -> Result<HashMap<String, AuthorizedKeySet>> {
         let dir_contents =
-            fs::read_dir(&dir).chain_err(|| format!("failed to read from directory {:?}", dir))?;
+            fs::read_dir(dir).chain_err(|| format!("failed to read from directory {:?}", dir))?;
         let mut keys = HashMap::new();
         for entry in dir_contents {
             let entry =


### PR DESCRIPTION
Address issues of `cargo fmt` as well as `cargo clippy`.

In CI, run also `cargo fmt` and `cargo test`.
Use `actions-rs/cargo` Github Actions.