### PR TITLE
Cargo: replace users with uzers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,16 +287,7 @@ dependencies = [
  "error-chain",
  "fs2",
  "openssh-keys",
- "users",
-]
-
-[[package]]
-name = "users"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
-dependencies = [
- "libc",
+ "uzers",
 ]
 
 [[package]]
@@ -298,6 +295,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ fs2 = "0.4"
 # Public dependencies, exposed through library API.
 error-chain = { version = "0.12", default-features = false }
 openssh-keys = { git = "https://github.com/pothos/openssh-keys", branch = "add-sk-keys" }
-users = "0.9"
 clap = { version = "4.4.6", features = ["cargo"] }
+uzers = "0.11.3"
 
 [[bin]]
 name = "update-ssh-keys"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 extern crate error_chain;
 extern crate fs2;
 extern crate openssh_keys;
-extern crate users;
+extern crate uzers;
 
 pub mod errors {
     error_chain! {
@@ -64,8 +64,8 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use users::os::unix::UserExt;
-use users::{switch, User};
+use uzers::os::unix::UserExt;
+use uzers::{switch, User};
 
 const SSH_DIR: &str = ".ssh";
 const AUTHORIZED_KEYS_DIR: &str = "authorized_keys.d";

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ extern crate clap;
 #[macro_use]
 extern crate error_chain;
 extern crate openssh_keys;
-extern crate users;
+extern crate uzers;
 
 extern crate update_ssh_keys;
 
@@ -29,7 +29,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use update_ssh_keys::errors::*;
 use update_ssh_keys::*;
-use users::get_current_username;
+use uzers::get_current_username;
 
 #[derive(Clone, Debug)]
 struct Config {
@@ -62,7 +62,7 @@ quick_main!(run);
 fn run() -> Result<()> {
     let config = config().chain_err(|| "command line configuration")?;
 
-    let user = users::get_user_by_name(&config.user)
+    let user = uzers::get_user_by_name(&config.user)
         .ok_or_else(|| format!("failed to find user with name '{}'", config.user))?;
 
     let mut aks = AuthorizedKeys::open(user, true, config.ssh_dir.clone()).chain_err(|| {


### PR DESCRIPTION
Crate `users` is unmaintained, so it is not possible to resolve a security issue of the crate.
https://github.com/flatcar/update-ssh-keys/security/dependabot/4.

So it is necessary to use instead an actively maintained fork, `uzers`.
