### PR TITLE
Cargo: replace coreos with flatcar, update author, version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "update-ssh-keys"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
-            "Luca Bruno <lucab@debian.org>" ]
+            "Luca Bruno <lucab@debian.org>",
+            "Dongsu Park <dpark@linux.microsoft.com>",
+            "Kai Lueke <kailuke@microsoft.com>" ]
 license = "Apache-2.0"
-repository = "https://github.com/coreos/update-ssh-keys"
+repository = "https://github.com/flatcar/update-ssh-keys"
 documentation = "https://docs.rs/update-ssh-keys"
 description = "A tool for managing authorized SSH keys"
-version = "0.4.2-alpha.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Replace `coreos` with `flatcar`, update author, version.
