### PR TITLE
Set number of args to 0 for no-replace and list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ extern crate uzers;
 
 extern crate update_ssh_keys;
 
+use clap::parser::ValueSource;
 use clap::{crate_version, Arg, Command};
 use std::fs::File;
 use std::path::PathBuf;
@@ -271,7 +272,11 @@ fn config() -> Result<Config> {
                 .map(|name| UssCommand::Disable { name: name.into() })
         })
         .unwrap_or(if matches.contains_id("list") {
-            UssCommand::List
+            if matches.value_source("list") == Some(ValueSource::CommandLine) {
+                UssCommand::List
+            } else {
+                UssCommand::Sync
+            }
         } else {
             UssCommand::Sync
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,11 +196,13 @@ fn config() -> Result<Config> {
         .arg(
             Arg::new("no-replace")
                 .short('n')
+                .num_args(0)
                 .help("When adding, don't replace an existing key with the given name."),
         )
         .arg(
             Arg::new("list")
                 .short('l')
+                .num_args(0)
                 .help("List the names and number of keys currently installed."),
         )
         .arg(


### PR DESCRIPTION
In case of clap 4, it is necessary to set the number of args to 0, if the option does not take any parameter.
