### PR TITLE
Update branch references in Rust CI workflow to use 'main' instead of 'flatcar-master'

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,10 @@ name: Run Rust CI
 on:
   push:
     branches:
-      - flatcar-master
+      - main
   pull_request:
     branches:
-      - flatcar-master
+      - main
 
 jobs:
   build-test:


### PR DESCRIPTION
This pull request updates the branch references in the Rust CI workflow configuration to align with the new branch naming conventions.

* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL6-R9): Updated the branch references from `flatcar-master` to `main` in both the `push` and `pull_request` triggers.


For reference: https://github.com/flatcar/Flatcar/issues/1714#issuecomment-2910117792